### PR TITLE
Added safeties on the trending of TOF QA

### DIFF
--- a/PWGPP/TOF/trending/MakeTrendingTOFQAv2.C
+++ b/PWGPP/TOF/trending/MakeTrendingTOFQAv2.C
@@ -105,6 +105,10 @@ Int_t MakeTrendingTOFQA(char * runlist,
   Int_t runNumber=-1;
   char infile[300];
   FILE * files = fopen(runlist, "r") ;
+  if (files == NULL){
+    ::Error("MakeTrendingTOFQA", "Error opening file %s", runlist);
+    return -1;
+  }
   while (fscanf(files,"%d",&runNumber)==1 ){
 
     //get QAtrain output
@@ -776,7 +780,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   if(hT0AvsNtracks){
     hT0AvsNtracks->Draw("colz");
     hT0AProfile->Draw("same");
-  } 
+  }
   else AddMissingLabel("hT0AvsNtrk");
 
   cT0vsMultiplicity->cd(4);

--- a/PWGPP/TOF/trending/MakeTrendingTOFQAv2.C
+++ b/PWGPP/TOF/trending/MakeTrendingTOFQAv2.C
@@ -49,8 +49,13 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,                   //full path of t
 
 Double_t GetGoodTOFChannelsRatio(Int_t run = -1, Bool_t saveMap = kFALSE, TString OCDBstorage = "raw://", Bool_t inEta08 = kFALSE);
 
-void MakeUpHisto(TH1* histo, TString titleY, Int_t marker = 20, Color_t color = kBlue+2);
+///
+///Function to setup the histogram style
+void MakeUpHisto(TH1* histo, TString titleY = "", Int_t marker = 20, Color_t color = kBlue+2, Int_t lineWidth = 1);
 
+///
+///Function add a label in a canvas, indicating a missing Plot
+void AddMissingLabel(const TString histoname = "");
 
 /********************************************************************************/
 Double_t TOFsignal(Double_t *x, Double_t *par)
@@ -592,77 +597,132 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   }
 
   //--------------------------------- T0 vs multiplicity plots ----------------------------------//
+  TList *ListOfOutput_T0 = new TList();///List of output for all plots related to T0
+  ListOfOutput_T0->SetOwner();
+  
   TH2F * hT0TOFvsNtracks=(TH2F*)timeZeroList->FindObject("hT0TOFvsNtrk");
-  Int_t binmin1 = hT0TOFvsNtracks->GetYaxis()->FindBin(-50.);
-  Int_t binmax1 = hT0TOFvsNtracks->GetYaxis()->FindBin(50.);
-  TProfile* hT0TOFProfile = (TProfile*)hT0TOFvsNtracks->ProfileX("hT0TOFProfile",binmin1,binmax1);
-  hT0TOFProfile->SetLineWidth(3);
-  hT0TOFProfile->SetLineColor(1);
+  TProfile* hT0TOFProfile = 0x0;
+  if(!hT0TOFvsNtracks) cout<<"Cannot find TH2F hT0TOFvsNtrk in the input list"<<endl;
+  else{
+    Int_t binmin1 = hT0TOFvsNtracks->GetYaxis()->FindBin(-50.);
+    Int_t binmax1 = hT0TOFvsNtracks->GetYaxis()->FindBin(50.);
+    hT0TOFProfile = (TProfile*)hT0TOFvsNtracks->ProfileX("hT0TOFProfile",binmin1,binmax1);
+    hT0TOFProfile->SetLineWidth(3);
+    hT0TOFProfile->SetLineColor(1);
+    
+    //Add result to output list
+    ListOfOutput_T0->Add(hT0TOFvsNtracks);
+    ListOfOutput_T0->Add(hT0TOFProfile);
+  }
 
   TH2F * hT0ACvsNtracks=(TH2F*)timeZeroList->FindObject("hT0ACvsNtrk");
-  Int_t binmin2 = hT0ACvsNtracks->GetYaxis()->FindBin(-50.);
-  Int_t binmax2 = hT0ACvsNtracks->GetYaxis()->FindBin(50.);
-  TProfile* hT0ACProfile = (TProfile*)hT0ACvsNtracks->ProfileX("hT0ACProfile",binmin2,binmax2);
-  hT0ACProfile->SetLineWidth(3);
-  hT0ACProfile->SetLineColor(1);
+  TProfile* hT0ACProfile = 0x0;
+  if(!hT0ACvsNtracks) cout<<"Cannot find TH2F hT0ACvsNtrk in the input list"<<endl;
+  else{
+    Int_t binmin2 = hT0ACvsNtracks->GetYaxis()->FindBin(-50.);
+    Int_t binmax2 = hT0ACvsNtracks->GetYaxis()->FindBin(50.);
+    hT0ACProfile = (TProfile*)hT0ACvsNtracks->ProfileX("hT0ACProfile",binmin2,binmax2);
+    hT0ACProfile->SetLineWidth(3);
+    hT0ACProfile->SetLineColor(1);
+    
+    //Add result to output list
+    ListOfOutput_T0->Add(hT0ACvsNtracks);
+    ListOfOutput_T0->Add(hT0ACProfile);
+	}
 
   TH2F * hT0AvsNtracks=(TH2F*)timeZeroList->FindObject("hT0AvsNtrk");
-  Int_t binmin3 = hT0AvsNtracks->GetYaxis()->FindBin(-50.);
-  Int_t binmax3 = hT0AvsNtracks->GetYaxis()->FindBin(50.);
-  TProfile* hT0AProfile = (TProfile*)hT0AvsNtracks->ProfileX("hT0AProfile",binmin3,binmax3);
-  hT0AProfile->SetLineWidth(3);
-  hT0AProfile->SetLineColor(1);
+  TProfile* hT0AProfile = 0x0;
+  if(!hT0AvsNtracks) cout<<"Cannot find TH2F hT0AvsNtrk in the input list"<<endl;
+  else{
+    Int_t binmin3 = hT0AvsNtracks->GetYaxis()->FindBin(-50.);
+    Int_t binmax3 = hT0AvsNtracks->GetYaxis()->FindBin(50.);
+    hT0AProfile = (TProfile*)hT0AvsNtracks->ProfileX("hT0AProfile",binmin3,binmax3);
+    hT0AProfile->SetLineWidth(3);
+    hT0AProfile->SetLineColor(1);
+    
+    //Add result to output list
+    ListOfOutput_T0->Add(hT0AvsNtracks);
+    ListOfOutput_T0->Add(hT0AProfile);
+  }
 
   TH2F * hT0CvsNtracks=(TH2F*)timeZeroList->FindObject("hT0CvsNtrk");
-  Int_t binmin4 = hT0CvsNtracks->GetYaxis()->FindBin(-50.);
-  Int_t binmax4 = hT0CvsNtracks->GetYaxis()->FindBin(50.);
-  TProfile* hT0CProfile = (TProfile*)hT0CvsNtracks->ProfileX("hT0CProfile",binmin4,binmax4);
-  hT0CProfile->SetLineWidth(3);
-  hT0CProfile->SetLineColor(1);
+  TProfile* hT0CProfile = 0x0;
+  if(!hT0CvsNtracks) cout<<"Cannot find TH2F hT0CvsNtrk in the input list"<<endl;
+  else{
+    Int_t binmin4 = hT0CvsNtracks->GetYaxis()->FindBin(-50.);
+    Int_t binmax4 = hT0CvsNtracks->GetYaxis()->FindBin(50.);
+    hT0CProfile = (TProfile*)hT0CvsNtracks->ProfileX("hT0CProfile",binmin4,binmax4);
+    hT0CProfile->SetLineWidth(3);
+    hT0CProfile->SetLineColor(1);
+    
+    //Add result to output list
+    ListOfOutput_T0->Add(hT0CvsNtracks);
+    ListOfOutput_T0->Add(hT0CProfile);
+  }
 
   TH2F * hStartTime=(TH2F*)timeZeroList->FindObject("hStartTime");
+  TProfile* hStartTimeProfile = 0x0;
+  if(!hStartTime) cout<<"Cannot find TH2F hStartTime in the input list"<<endl;
+  else{
+    Int_t binminst = hStartTime->GetXaxis()->FindBin(-600.);
+    Int_t binmaxst = hStartTime->GetXaxis()->FindBin(600.);
+    hStartTimeProfile = (TProfile*) hStartTime->ProfileY("hStartTimeProfile",binminst,binmaxst);
+    hStartTimeProfile->SetFillStyle(0);
+    hStartTimeProfile->SetLineWidth(3);
+    hStartTimeProfile->SetLineColor(1);
+    
+    //Add result to output list
+    ListOfOutput_T0->Add(hStartTime);
+    ListOfOutput_T0->Add(hStartTimeProfile);
+    
+    //Set Start Time information
+    StartTime_pBestT0 = hStartTimeProfile->GetBinContent(1);
+    StartTime_pBestT0Err = hStartTimeProfile->GetBinError(1);
+    
+    StartTime_pFillT0 = hStartTimeProfile->GetBinContent(2);
+    StartTime_pFillT0Err = hStartTimeProfile->GetBinError(2);
+    
+    StartTime_pTOFT0 = hStartTimeProfile->GetBinContent(3);
+    StartTime_pTOFT0Err = hStartTimeProfile->GetBinError(3);
+    
+    StartTime_pT0ACT0 = hStartTimeProfile->GetBinContent(4);
+    StartTime_pT0ACT0Err = hStartTimeProfile->GetBinError(4);
+    
+    StartTime_pT0AT0 = hStartTimeProfile->GetBinContent(5);
+    StartTime_pT0AT0Err = hStartTimeProfile->GetBinError(5);
+    
+    StartTime_pT0CT0 = hStartTimeProfile->GetBinContent(6);
+    StartTime_pT0CT0Err = hStartTimeProfile->GetBinError(6);
+  }
+  
   TH2F * hStartTimeRes=(TH2F*)timeZeroList->FindObject("hStartTimeRes");
-
-  Int_t binminst = hStartTime->GetXaxis()->FindBin(-600.);
-  Int_t binmaxst = hStartTime->GetXaxis()->FindBin(600.);
-
-  TProfile* hStartTimeProfile = (TProfile*) hStartTime->ProfileY("hStartTimeProfile",binminst,binmaxst);
-  hStartTimeProfile->SetFillStyle(0);
-  hStartTimeProfile->SetLineWidth(3);
-  hStartTimeProfile->SetLineColor(1);
-
-  Int_t binminstRes = hStartTimeRes->GetXaxis()->FindBin(-600.);
-  Int_t binmaxstRes = hStartTimeRes->GetXaxis()->FindBin(600.);
-
-  TProfile* hStartTimeResProfile = (TProfile*) hStartTimeRes->ProfileY("hStartTimeResProfile",binminstRes,binmaxstRes);
-  hStartTimeResProfile->SetFillStyle(0);
-  hStartTimeResProfile->SetLineWidth(3);
-  hStartTimeResProfile->SetLineColor(1);
-
-  StartTime_pBestT0 = hStartTimeProfile->GetBinContent(1);
-  StartTime_pBestT0Err = hStartTimeProfile->GetBinError(1);
-
-  StartTime_pFillT0 = hStartTimeProfile->GetBinContent(2);
-  StartTime_pFillT0Err = hStartTimeProfile->GetBinError(2);
-
-  StartTime_pTOFT0 = hStartTimeProfile->GetBinContent(3);
-  StartTime_pTOFT0Err = hStartTimeProfile->GetBinError(3);
-
-  StartTime_pT0ACT0 = hStartTimeProfile->GetBinContent(4);
-  StartTime_pT0ACT0Err = hStartTimeProfile->GetBinError(4);
-
-  StartTime_pT0AT0 = hStartTimeProfile->GetBinContent(5);
-  StartTime_pT0AT0Err = hStartTimeProfile->GetBinError(5);
-
-  StartTime_pT0CT0 = hStartTimeProfile->GetBinContent(6);
-  StartTime_pT0CT0Err = hStartTimeProfile->GetBinError(6);
-
-  StartTime_pBestT0_Res = hStartTimeResProfile->GetBinContent(1);
-  StartTime_pFillT0_Res = hStartTimeResProfile->GetBinContent(2);
-  StartTime_pTOFT0_Res = hStartTimeResProfile->GetBinContent(3);
-  StartTime_pT0ACT0_Res = hStartTimeResProfile->GetBinContent(4);
-  StartTime_pT0AT0_Res = hStartTimeResProfile->GetBinContent(5);
-  StartTime_pT0CT0_Res = hStartTimeResProfile->GetBinContent(6);
+  TProfile* hStartTimeResProfile = 0x0;
+  if(!hStartTimeRes) cout<<"Cannot find TH2F hStartTimeRes in the input list"<<endl;
+  else{
+    Int_t binminstRes = hStartTimeRes->GetXaxis()->FindBin(-600.);
+    Int_t binmaxstRes = hStartTimeRes->GetXaxis()->FindBin(600.);
+    hStartTimeResProfile = (TProfile*) hStartTimeRes->ProfileY("hStartTimeResProfile",binminstRes,binmaxstRes);
+    hStartTimeResProfile->SetFillStyle(0);
+    hStartTimeResProfile->SetLineWidth(3);
+    hStartTimeResProfile->SetLineColor(1);
+    
+    //Add result to output list
+    ListOfOutput_T0->Add(hStartTimeRes);
+    ListOfOutput_T0->Add(hStartTimeResProfile);
+    
+    //Set Start Time Resolution information
+    StartTime_pBestT0_Res = hStartTimeResProfile->GetBinContent(1);
+    
+    StartTime_pFillT0_Res = hStartTimeResProfile->GetBinContent(2);
+    
+    StartTime_pTOFT0_Res = hStartTimeResProfile->GetBinContent(3);
+    
+    StartTime_pT0ACT0_Res = hStartTimeResProfile->GetBinContent(4);
+    
+    StartTime_pT0AT0_Res = hStartTimeResProfile->GetBinContent(5);
+    
+    StartTime_pT0CT0_Res = hStartTimeResProfile->GetBinContent(6);
+  }
 
   // cout << "StartTimeBest  " << StartTime_pBestT0 << " ps" << endl;
   // cout << "StartTimeBestErr  " << StartTime_pBestT0Err << " ps" << endl;
@@ -683,6 +743,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   // cout << "StartTimeT0C  " << StartTime_pT0CT0 << " ps" << endl;
   // cout << "Res StartTimeT0C  " << StartTime_pT0CT0_Res << " ps" << endl;
 
+  //Drawing section
   TCanvas *cT0vsMultiplicity = new TCanvas("cT0vsMultiplicity","T0TOF,T0C,T0A,TOAC vs N_TOF,",1200,800);
   cT0vsMultiplicity->Divide(2,2);
   cT0vsMultiplicity->cd(1);
@@ -690,44 +751,58 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   gPad->SetLogx();
   gPad->SetGridx();
   gPad->SetGridy();
-  hT0TOFvsNtracks->Draw("colz");
-  hT0TOFProfile->Draw("same");
+  if(hT0TOFvsNtracks){
+    hT0TOFvsNtracks->Draw("colz");
+    hT0TOFProfile->Draw("same");
+  }
+  else AddMissingLabel("hT0TOFvsNtrk");
 
   cT0vsMultiplicity->cd(2);
   gPad->SetLogz();
   gPad->SetLogx();
   gPad->SetGridx();
   gPad->SetGridy();
-  hT0ACvsNtracks->Draw("colz");
-  hT0ACProfile->Draw("same");
+  if(hT0ACvsNtracks){
+    hT0ACvsNtracks->Draw("colz");
+    hT0ACProfile->Draw("same");
+  }
+  else AddMissingLabel("hT0ACvsNtrk");
 
   cT0vsMultiplicity->cd(3);
   gPad->SetLogz();
   gPad->SetLogx();
   gPad->SetGridx();
   gPad->SetGridy();
-  hT0AvsNtracks->Draw("colz");
-  hT0AProfile->Draw("same");
+  if(hT0AvsNtracks){
+    hT0AvsNtracks->Draw("colz");
+    hT0AProfile->Draw("same");
+  } 
+  else AddMissingLabel("hT0AvsNtrk");
 
   cT0vsMultiplicity->cd(4);
   gPad->SetLogz();
   gPad->SetLogx();
   gPad->SetGridx();
   gPad->SetGridy();
-  hT0CvsNtracks->Draw("colz");
-  hT0CProfile->Draw("same");
-
-  TCanvas *cStartTimeRes = new TCanvas("cStartTimeRes","Resolution of start time methods",1200,800);
-  gPad->SetLogz();
-  gPad->SetGridx();
-  gPad->SetGridy();
-  hStartTimeRes->Draw("colz");
+  if(hT0CvsNtracks){
+    hT0CvsNtracks->Draw("colz");
+    hT0CProfile->Draw("same");
+  }
+  else AddMissingLabel("hT0CvsNtrk");
 
   TCanvas *cStartTime = new TCanvas("cStartTime","start time with different methods",1200,800);
   gPad->SetLogz();
   gPad->SetGridx();
   gPad->SetGridy();
-  hStartTime->Draw("colz");
+  if(hStartTime) hStartTime->Draw("colz");
+  else AddMissingLabel("hStartTime");
+
+  TCanvas *cStartTimeRes = new TCanvas("cStartTimeRes","Resolution of start time methods",1200,800);
+  gPad->SetLogz();
+  gPad->SetGridx();
+  gPad->SetGridy();
+  if(hStartTimeRes) hStartTimeRes->Draw("colz");
+  else AddMissingLabel("hStartTimeRes");
 
   if (savePng) {
     cT0vsMultiplicity->Print(Form("%s/%i%s_T0vsMultiplicity.png", plotDir.Data(), runNumber, dirsuffix.Data()));
@@ -736,18 +811,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   }
   if (saveHisto) {
     trendFile->cd();
-    hT0TOFvsNtracks->Write();
-    hT0TOFProfile->Write();
-    hT0ACvsNtracks->Write();
-    hT0ACProfile->Write();
-    hT0CvsNtracks->Write();
-    hT0CProfile->Write();
-    hT0AvsNtracks->Write();
-    hT0AProfile->Write();
-    hStartTime->Write();
-    hStartTimeRes->Write();
-    hStartTimeProfile->Write();
-    hStartTimeResProfile->Write();
+    ListOfOutput_T0->Write();
+    delete ListOfOutput_T0;
   }
 
   //--------------------------------- NSigma PID from TOF QA ----------------------------------//
@@ -1468,7 +1533,7 @@ Double_t GetGoodTOFChannelsRatio(Int_t run, Bool_t saveMap , TString OCDBstorage
 }
 
 //----------------------------------------------------------
-void MakeUpHisto(TH1* histo, TString titleY = "", Int_t marker = 1, Color_t color = kBlue+1, Int_t lineWidth = 1)
+void MakeUpHisto(TH1* histo, TString titleY, Int_t marker, Color_t color, Int_t lineWidth)
 {
   if (!histo) return;
   histo->SetMarkerStyle(marker);
@@ -1482,4 +1547,16 @@ void MakeUpHisto(TH1* histo, TString titleY = "", Int_t marker = 1, Color_t colo
   histo->GetYaxis()->SetTitleOffset(1.35);
   histo->GetXaxis()->SetLabelSize(0.03);
   return;
+}
+
+//----------------------------------------------------------
+void AddMissingLabel(const TString histoname){
+  TPaveText missing(0.3, 0.5, 0.7, 0.8, "NDC NB");//For canvases missing plots
+  missing.SetFillColor(0);
+  missing.SetFillStyle(0);
+  missing.SetLineColor(0);
+  missing.SetLineWidth(0);
+  missing.SetBorderSize(0);
+  missing.AddText(Form("Plot%s%s Missing", histoname.IsNull() ? "" : " ", histoname.Data()));
+  missing.Draw();
 }


### PR DESCRIPTION
- Correction of minor compilation bug
- Correction of compatibility minor bugs which prevented QA on data with old versions of aliroot
- Added list of output for direct writing of histograms to file of T0 plots
- Saving only histograms which are available, check on the existence of the histograms to show. This is done so as to avoid unwanted breaks of the code
- Canvases of Plots which are NOT FOUND are always created. A placeholder is drawn instead of the actual histogram.
- Added check on the existence of the input file runlist